### PR TITLE
Add TemplateControl and hook up custom library

### DIFF
--- a/AvaloniaApplication1/App.axaml
+++ b/AvaloniaApplication1/App.axaml
@@ -11,6 +11,6 @@
   
     <Application.Styles>
         <FluentTheme />
-			  <!--<StyleInclude Source="avares://>-->
+        <StyleInclude Source="avares://AvaloniaControls/Themes/Generic.axaml" />
     </Application.Styles>
 </Application>

--- a/AvaloniaApplication1/AvaloniaApplication1.csproj
+++ b/AvaloniaApplication1/AvaloniaApplication1.csproj
@@ -25,4 +25,8 @@
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AvaloniaControls\AvaloniaControls.csproj" />
+  </ItemGroup>
 </Project>

--- a/AvaloniaApplication1/Views/MainWindow.axaml
+++ b/AvaloniaApplication1/Views/MainWindow.axaml
@@ -3,7 +3,7 @@
         xmlns:vm="using:AvaloniaApplication1.ViewModels"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:my="rems"
+        xmlns:ctrls="clr-namespace:AvaloniaControls;assembly=AvaloniaControls"
 				mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="AvaloniaApplication1.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
@@ -17,8 +17,9 @@
         <vm:MainWindowViewModel/>
     </Design.DataContext>
 
-	<StackPanel>
-    <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-		
-	</StackPanel>
+        <StackPanel>
+            <ctrls:TemplateControl Title="Custom Title">
+                <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </ctrls:TemplateControl>
+        </StackPanel>
 </Window>

--- a/AvaloniaControls/TemplateControl.cs
+++ b/AvaloniaControls/TemplateControl.cs
@@ -1,0 +1,17 @@
+using Avalonia;
+using Avalonia.Controls.Primitives;
+
+namespace AvaloniaControls
+{
+    public class TemplateControl : TemplatedControl
+    {
+        public static readonly StyledProperty<string?> TitleProperty =
+            AvaloniaProperty.Register<TemplateControl, string?>(nameof(Title));
+
+        public string? Title
+        {
+            get => GetValue(TitleProperty);
+            set => SetValue(TitleProperty, value);
+        }
+    }
+}

--- a/AvaloniaControls/Themes/Generic.axaml
+++ b/AvaloniaControls/Themes/Generic.axaml
@@ -2,15 +2,25 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:AvaloniaControls;assembly=AvaloniaControls">
 
-	<Style Selector="local|MyCustomControl">
-		<Setter Property="Template">
-			<ControlTemplate>
-				<StackPanel>
-					<TextBlock Text="{TemplateBinding Title}" FontSize="20"/>
-					<ContentPresenter/>
-				</StackPanel>
-			</ControlTemplate>
-		</Setter>
-	</Style>
+        <Style Selector="local|MyCustomControl">
+                <Setter Property="Template">
+                        <ControlTemplate>
+                                <StackPanel>
+                                        <TextBlock Text="{TemplateBinding Title}" FontSize="20"/>
+                                        <ContentPresenter/>
+                                </StackPanel>
+                        </ControlTemplate>
+                </Setter>
+        </Style>
+
+        <Style Selector="local|TemplateControl">
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <local:MyCustomControl Title="{TemplateBinding Title}">
+                        <ContentPresenter/>
+                    </local:MyCustomControl>
+                </ControlTemplate>
+            </Setter>
+        </Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
## Summary
- add `TemplateControl` templated control in `AvaloniaControls`
- add style for `TemplateControl` that uses `MyCustomControl`
- expose library resources in the application
- reference `AvaloniaControls` from the main project
- demo `TemplateControl` in `MainWindow`

## Testing
- `dotnet build AvaloniaApplication1.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688abb9e61048328b26b1b155a70f83c